### PR TITLE
Provide client access to relay status

### DIFF
--- a/relay.js
+++ b/relay.js
@@ -114,6 +114,9 @@ export function relayConnect(url, onEvent, onNotice) {
     },
     close() {
       ws.close()
+    },
+    get status() {
+      return ws.readyState
     }
   }
 }


### PR DESCRIPTION
This provides a way for a client to check if a relay is online by checking against `WebSocket.OPEN`.  Or it could be just an `online` getter instead that checks internally, whatever you like, not sure if there is an advantage to checking the other states or not.