### PR TITLE
Add build for use in nodejs environment

### DIFF
--- a/index.cjs.js
+++ b/index.cjs.js
@@ -1,0 +1,5 @@
+import WebSocket from 'ws'
+global.WebSocket = WebSocket
+import * as nostr from './index'
+
+export default nostr

--- a/package.json
+++ b/package.json
@@ -2,14 +2,20 @@
   "name": "nostr-tools",
   "version": "0.3.2",
   "description": "Tools for making a Nostr client.",
-  "main": "index.js",
+  "main": "dist/nostr-tools.cjs.js",
+  "module": "index.js",
+  "browser": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/fiatjaf/nostr-tools.git"
   },
+  "scripts": {
+    "build": "rollup -c"
+  },
   "dependencies": {
     "buffer": "^6.0.3",
-    "noble-secp256k1": "^1.1.1"
+    "noble-secp256k1": "^1.1.1",
+    "ws": "^7.4.3"
   },
   "keywords": [
     "decentralization",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+import pkg from './package.json';
+
+export default [
+	{
+		input: 'index.cjs.js',
+		external: [
+			"buffer",
+			"noble-secp256k1",
+			"ws"
+		],
+		output: [
+			{ file: pkg.main, format: 'cjs' }
+		]
+	}
+];


### PR DESCRIPTION
This builds as a node module leaving the `index.js` as the entry point otherwise.  `WebSocket` is native to the browser but the `ws` package is imported for node