### PR TITLE
Correct subscriptions for new protocol

### DIFF
--- a/relay.js
+++ b/relay.js
@@ -115,13 +115,13 @@ export function relayConnect(url, onNotice) {
     }
   }
 
-  const sub = async ({cb, filter}) => {
-    const channel = (await sha256(Math.random().toString())).reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '')
+  const sub = async ({ch, cb, filter}) => {
+    const channel = ch || (await sha256(Math.random().toString())).reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '')
     trySend(['REQ', channel, filter])
     channels[channel] = cb
 
     return {
-      sub: ({cb = cb, filter = filter}) => sub(channel, {cb, filter}),
+      sub: ({cb = cb, filter = filter}) => sub({ch: channel, cb, filter}),
       unsub: () => trySend(['CLOSE', channel])
     }
   }

--- a/relay.js
+++ b/relay.js
@@ -85,8 +85,7 @@ export function relayConnect(url, onNotice) {
           } else {
             console.warn(
               'got event with invalid signature from ' + url,
-              event,
-              id
+              event
             )
           }
           return
@@ -116,7 +115,8 @@ export function relayConnect(url, onNotice) {
     }
   }
 
-  const sub = async (channel, {cb, filter}) => {
+  const sub = async ({cb, filter}) => {
+    const channel = (await sha256(Math.random().toString())).reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '')
     trySend(['REQ', channel, filter])
     channels[channel] = cb
 
@@ -128,9 +128,9 @@ export function relayConnect(url, onNotice) {
 
   return {
     url,
-    sub: sub.bind(null, await sha256(Math.random().toString())),
+    sub,
     async publish(event) {
-      trySend(JSON.stringify(['EVENT', event]))
+      trySend(['EVENT', event])
     },
     close() {
       ws.close()


### PR DESCRIPTION
I think most of these changes should be obvious, relay.js line 89, id does not exist so removed from log

The bind on the channel was only bound once, on return so it kept the same value for every subscription.  I moved it to `sub` and also added the reduce to convert to hex

And `trySend` already stringifies, so it was removed from `realy.publish`