### PR TITLE
Return relay with sub callback for new relay

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -32,7 +32,7 @@ export function relayPool(globalPrivateKey) {
           sub(id, {cb, filter})
         ]),
       addRelay: relay => {
-        subControllers[relay.url] = relay.sub({cb, filter})
+        subControllers[relay.url] = relay.sub({filter, cb: event => cb(event, relay)})
       },
       removeRelay: relayURL => {
         subControllers[relayURL].unsub()


### PR DESCRIPTION
I don't quite understand well enough but this is what I observe to be occurring
[here](https://github.com/rsbondi/nostr-tools/blob/6750a6cc7659a58cd8cc646c7001aa2ead98c977/pool.js#L35)(this commit) will catch it the first time when the relay is first added, and [here](https://github.com/rsbondi/nostr-tools/blob/6750a6cc7659a58cd8cc646c7001aa2ead98c977/pool.js#L24) on subscriptions that are added after

So if I subscribe, then add an additional relay, it is covered by this PR