### PR TITLE
import 'Buffer'

### DIFF
--- a/keys.js
+++ b/keys.js
@@ -1,4 +1,5 @@
 import * as secp256k1 from '@noble/secp256k1'
+import {Buffer} from 'buffer'
 
 export function generatePrivateKey() {
   return Buffer.from(secp256k1.utils.randomPrivateKey()).toString('hex')


### PR DESCRIPTION
'Buffer' wasn't imported initially and was causing issues when I tried to use generatePrivateKey in a client I am building. not sure why Branle has no error, maybe I am doing something wrong?