### PR TITLE
feat: add beforeSend hook to sub()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-tools",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "Tools for making a Nostr client.",
   "repository": {
     "type": "git",

--- a/pool.js
+++ b/pool.js
@@ -26,27 +26,35 @@ export function relayPool() {
 
   const activeSubscriptions = {}
 
-  const sub = ({cb, filter}, id = Math.random().toString().slice(2)) => {
+  const sub = (
+    {cb, filter, beforeSend},
+    id = Math.random().toString().slice(2)
+  ) => {
     const subControllers = Object.fromEntries(
       Object.values(relays)
         .filter(({policy}) => policy.read)
         .map(({relay}) => [
           relay.url,
-          relay.sub({filter, cb: event => cb(event, relay.url)}, id)
+          relay.sub({filter, cb: event => cb(event, relay.url), beforeSend}, id)
         ])
     )
 
     const activeCallback = cb
     const activeFilters = filter
+    const activeBeforeSend = beforeSend
 
     const unsub = () => {
       Object.values(subControllers).forEach(sub => sub.unsub())
       delete activeSubscriptions[id]
     }
-    const sub = ({cb = activeCallback, filter = activeFilters}) => {
+    const sub = ({
+      cb = activeCallback,
+      filter = activeFilters,
+      beforeSend = activeBeforeSend
+    }) => {
       Object.entries(subControllers).map(([relayURL, sub]) => [
         relayURL,
-        sub.sub({cb, filter}, id)
+        sub.sub({cb, filter, beforeSend}, id)
       ])
       return activeSubscriptions[id]
     }


### PR DESCRIPTION
Using the `beforeSend` hook on Branle, adding `since` to each filter to the main subscription.

```js
      beforeSend: ({filter, relay}) => {
        console.log(`beforeSend: filters for relay: ${relay}`, filter)
        const newFilter = filter.map(f => ({
          ...f,
          since: Math.floor(Date.now() / 1000) - 24 * 60 * 60
        }))
        return {filter: newFilter}
      },
```

![image](https://user-images.githubusercontent.com/378886/162643221-113da7a9-5e9b-463b-b8d9-ec217aba6fc8.png)


