### PR TITLE
update cb property in subControllers relay entry

### DIFF
--- a/pool.js
+++ b/pool.js
@@ -34,7 +34,7 @@ export function relayPool() {
         .filter(({policy}) => policy.read)
         .map(({relay}) => [
           relay.url,
-          relay.sub({filter, cb: event => cb(event, relay.url), beforeSend}, id)
+          relay.sub({ cb: event => cb(event, relay.url), filter, beforeSend}, id)
         ])
     )
 
@@ -53,12 +53,12 @@ export function relayPool() {
     }) => {
       Object.entries(subControllers).map(([relayURL, sub]) => [
         relayURL,
-        sub.sub({cb, filter, beforeSend}, id)
+        sub.sub({cb: event => cb(event, relayURL), filter, beforeSend}, id)
       ])
       return activeSubscriptions[id]
     }
     const addRelay = relay => {
-      subControllers[relay.url] = relay.sub({cb, filter}, id)
+      subControllers[relay.url] = relay.sub({cb: event => cb(event, relay.url), filter}, id)
       return activeSubscriptions[id]
     }
     const removeRelay = relayURL => {

--- a/pool.js
+++ b/pool.js
@@ -53,12 +53,12 @@ export function relayPool() {
     }) => {
       Object.entries(subControllers).map(([relayURL, sub]) => [
         relayURL,
-        sub.sub({cb: event => cb(event, relayURL), filter, beforeSend}, id)
+        sub.sub({ cb: event => cb(event, relayURL), filter, beforeSend }, id)
       ])
       return activeSubscriptions[id]
     }
     const addRelay = relay => {
-      subControllers[relay.url] = relay.sub({cb: event => cb(event, relay.url), filter}, id)
+      subControllers[relay.url] = relay.sub({ cb: event => cb(event, relay.url), filter, beforeSend }, id)
       return activeSubscriptions[id]
     }
     const removeRelay = relayURL => {


### PR DESCRIPTION
when updating subscription or adding new relays, subsequent events that are received have the relay as undefined. by updating cb property for the subControllers entries to be an arrow function (when calling sub.sub or sub.addRelay), subsequent events now return the relay url appropriately.

I also rearranged order in line 37 so that order is consistent throughout.