### PR TITLE
fix: CJK characters are garbled after decryption

### DIFF
--- a/nip04.js
+++ b/nip04.js
@@ -29,7 +29,7 @@ export function decrypt(privkey, pubkey, ciphertext) {
     Buffer.from(normalizedKey, 'hex'),
     Buffer.from(iv, 'base64')
   )
-  let decryptedMessage = decipher.update(cip, 'base64')
+  let decryptedMessage = decipher.update(cip, 'base64', 'utf8')
   decryptedMessage += decipher.final('utf8')
 
   return decryptedMessage


### PR DESCRIPTION
I'm from Asia and I found that CJK characters are garbled after decryption.
Because during decryption, parameters of `decipher.update` does not contain `outputEncoding`.

Test code:
```Javscript
import { decrypt, encrypt } from './nip04.js'

const main = function() {
  let priv = '3277614521b0dba8ec930e64ff4ea5bb2709dfd67d35586b8b380d0beeb420c1'
  let pub = '8643c759c757bbaf06eae40ac4454627ec44731a7f48a4ba04244b68fd028999'
  let txt = '苟利国家生死以，岂因祸福避趋之'
  let cipText = encrypt(priv, pub, txt)
  let r = decrypt(priv, pub, cipText)
  console.log(r)
}

main()
```
Result:
![image](https://user-images.githubusercontent.com/8938315/188699826-01cdf02f-7d68-4d69-a81d-8893ac792ee3.png)

After repair:
![image](https://user-images.githubusercontent.com/8938315/188700035-ebaca5fe-600c-4971-8d02-e00acac8c4d5.png)
