### PR TITLE
modify ./nip04.js to use buffer npm package

### DIFF
--- a/event.js
+++ b/event.js
@@ -1,58 +1,49 @@
-import {Buffer} from 'buffer'
-import createHash from 'create-hash'
-import * as secp256k1 from '@noble/secp256k1'
+import { Buffer } from "buffer/";
+import createHash from "create-hash";
+import * as secp256k1 from "@noble/secp256k1";
 
 export function getBlankEvent() {
-  return {
-    kind: 255,
-    pubkey: null,
-    content: '',
-    tags: [],
-    created_at: 0
-  }
+	return {
+		kind: 255,
+		pubkey: null,
+		content: "",
+		tags: [],
+		created_at: 0,
+	};
 }
 
 export function serializeEvent(evt) {
-  return JSON.stringify([
-    0,
-    evt.pubkey,
-    evt.created_at,
-    evt.kind,
-    evt.tags,
-    evt.content
-  ])
+	return JSON.stringify([0, evt.pubkey, evt.created_at, evt.kind, evt.tags, evt.content]);
 }
 
 export function getEventHash(event) {
-  let eventHash = createHash('sha256')
-    .update(Buffer.from(serializeEvent(event)))
-    .digest()
-  return Buffer.from(eventHash).toString('hex')
+	let eventHash = createHash("sha256")
+		.update(Buffer.from(serializeEvent(event)))
+		.digest();
+	return Buffer.from(eventHash).toString("hex");
 }
 
 export function validateEvent(event) {
-  if (event.id !== getEventHash(event)) return false
-  if (typeof event.content !== 'string') return false
-  if (typeof event.created_at !== 'number') return false
+	if (event.id !== getEventHash(event)) return false;
+	if (typeof event.content !== "string") return false;
+	if (typeof event.created_at !== "number") return false;
 
-  if (!Array.isArray(event.tags)) return false
-  for (let i = 0; i < event.tags.length; i++) {
-    let tag = event.tags[i]
-    if (!Array.isArray(tag)) return false
-    for (let j = 0; j < tag.length; j++) {
-      if (typeof tag[j] === 'object') return false
-    }
-  }
+	if (!Array.isArray(event.tags)) return false;
+	for (let i = 0; i < event.tags.length; i++) {
+		let tag = event.tags[i];
+		if (!Array.isArray(tag)) return false;
+		for (let j = 0; j < tag.length; j++) {
+			if (typeof tag[j] === "object") return false;
+		}
+	}
 
-  return true
+	return true;
 }
 
 export function verifySignature(event) {
-  return secp256k1.schnorr.verify(event.sig, event.id, event.pubkey)
+	return secp256k1.schnorr.verify(event.sig, event.id, event.pubkey);
 }
 
 export async function signEvent(event, key) {
-  return Buffer.from(
-    await secp256k1.schnorr.sign(getEventHash(event), key)
-  ).toString('hex')
+	return Buffer.from(await secp256k1.schnorr.sign(getEventHash(event), key)).toString("hex");
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { type Buffer } from 'buffer';
+import { type Buffer } from "buffer/";
 
 // these should be available from the native @noble/secp256k1 type
 // declarations, but they somehow aren't so instead: copypasta
@@ -6,21 +6,21 @@ declare type Hex = Uint8Array | string;
 declare type PrivKey = Hex | bigint | number;
 
 declare enum EventKind {
-    Metadata = 0,
-    Text = 1,
-    RelayRec = 2,
-    Contacts = 3,
-    DM = 4,
-    Deleted = 5,
+	Metadata = 0,
+	Text = 1,
+	RelayRec = 2,
+	Contacts = 3,
+	DM = 4,
+	Deleted = 5,
 }
 
 // event.js
 declare type Event = {
-    kind: EventKind,
-    pubkey?: string,
-    content: string,
-    tags: string[],
-    created_at: number,
+	kind: EventKind;
+	pubkey?: string;
+	content: string;
+	tags: string[];
+	created_at: number;
 };
 
 declare function getBlankEvent(): Event;
@@ -32,27 +32,22 @@ declare function signEvent(event: Event, key: PrivKey): Promise<[Uint8Array, num
 
 // filter.js
 declare type Filter = {
-    ids: string[],
-    kinds: EventKind[],
-    authors: string[],
-    since: number,
-    until: number,
-    "#e": string[],
-    "#p": string[],
+	ids: string[];
+	kinds: EventKind[];
+	authors: string[];
+	since: number;
+	until: number;
+	"#e": string[];
+	"#p": string[];
 };
 
 declare function matchFilter(filter: Filter, event: Event): boolean;
 declare function matchFilters(filters: Filter[], event: Event): boolean;
 
 // general
-declare type ClientMessage =
-    ["EVENT", Event] |
-    ["REQ", string, Filter[]] |
-    ["CLOSE", string];
+declare type ClientMessage = ["EVENT", Event] | ["REQ", string, Filter[]] | ["CLOSE", string];
 
-declare type ServerMessage =
-    ["EVENT", string, Event] |
-    ["NOTICE", unknown];
+declare type ServerMessage = ["EVENT", string, Event] | ["NOTICE", unknown];
 
 // keys.js
 declare function generatePrivateKey(): string;
@@ -60,42 +55,42 @@ declare function getPublicKey(privateKey: Buffer): string;
 
 // pool.js
 declare type RelayPolicy = {
-    read: boolean,
-    write: boolean,
+	read: boolean;
+	write: boolean;
 };
 
 declare type SubscriptionCallback = (event: Event, relay: string) => void;
 
 declare type SubscriptionOptions = {
-    cb: SubscriptionCallback,
-    filter: Filter,
-    skipVerification: boolean
-    // TODO: thread through how `beforeSend` actually works before trying to type it
-    // beforeSend(event: Event): 
+	cb: SubscriptionCallback;
+	filter: Filter;
+	skipVerification: boolean;
+	// TODO: thread through how `beforeSend` actually works before trying to type it
+	// beforeSend(event: Event):
 };
 
 declare type Subscription = {
-    unsub(): void,
+	unsub(): void;
 };
 
 declare type PublishCallback = (status: number) => void;
 
 // relay.js
 declare type Relay = {
-    url: string,
-    sub: SubscriptionCallback,
-    publish: (event: Event, cb: PublishCallback) => Promise<Event>,
+	url: string;
+	sub: SubscriptionCallback;
+	publish: (event: Event, cb: PublishCallback) => Promise<Event>;
 };
 
 declare type PoolPublishCallback = (status: number, relay: string) => void;
 
 declare type RelayPool = {
-    setPrivateKey(key: string): void,
-    addRelay(url: string, opts?: RelayPolicy): Relay,
-    sub(opts: SubscriptionOptions, id?: string): Subscription,
-    publish(event: Event, cb: PoolPublishCallback): Promise<Event>,
-    close: () => void,
-    status: number,
+	setPrivateKey(key: string): void;
+	addRelay(url: string, opts?: RelayPolicy): Relay;
+	sub(opts: SubscriptionOptions, id?: string): Subscription;
+	publish(event: Event, cb: PoolPublishCallback): Promise<Event>;
+	close: () => void;
+	status: number;
 };
 
 declare function relayPool(): RelayPool;

--- a/keys.js
+++ b/keys.js
@@ -1,10 +1,10 @@
-import * as secp256k1 from '@noble/secp256k1'
-import {Buffer} from 'buffer'
+import * as secp256k1 from "@noble/secp256k1";
+import { Buffer } from "buffer/";
 
 export function generatePrivateKey() {
-  return Buffer.from(secp256k1.utils.randomPrivateKey()).toString('hex')
+	return Buffer.from(secp256k1.utils.randomPrivateKey()).toString("hex");
 }
 
 export function getPublicKey(privateKey) {
-  return Buffer.from(secp256k1.schnorr.getPublicKey(privateKey)).toString('hex')
+	return Buffer.from(secp256k1.schnorr.getPublicKey(privateKey)).toString("hex");
 }

--- a/nip04.js
+++ b/nip04.js
@@ -1,5 +1,5 @@
 import aes from 'browserify-cipher'
-import {Buffer} from 'buffer'
+import {Buffer} from 'buffer/'
 import {randomBytes} from '@noble/hashes/utils'
 import * as secp256k1 from '@noble/secp256k1'
 


### PR DESCRIPTION
This will use the npm package instead of node's core module. 

The README for the buffer package from NPM (https://github.com/feross/buffer#usage) mentions using `'buffer/'` instead of `'buffer'`, since `'buffer'` will resolve to Node's Buffer module.