### PR TITLE
refactor of cb api

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,41 +14,59 @@ pool.setPrivateKey('<hex>') // optional
 pool.addRelay('ws://some.relay.com', {read: true, write: true})
 pool.addRelay('ws://other.relay.cool', {read: true, write: true})
 
-// example callback function for a subscription
-function onEvent(event, relay) {
-  console.log(`got an event from ${relay.url} which is already validated.`, event)
+// example callback functions for listeners
+// callback functions take an object argument with following keys:
+//  - relay: relay url
+//  - type: type of listener
+//  - id: sub id for sub specific listeners ('EVENT' or 'EOSE')
+//  - event: event object, only for 'event' listener
+//  - notice: notice message, only for 'notice' listener
+function onEvent({event, relay, type, id}) {
+  console.log(`got an event from ${relay} which is already validated.`, event)
 }
+function onEose({relay, type, id}) { /* callback function here */}
+function onNotice({relay, type, notice}) { /* callback function here */}
+function onConnection({relay, type}) { /* callback function here */}
+
+// listen for messages for pool
+pool.on('event', onEvent)
+pool.on('connection', onConnection)
+pool.on('notice', onNotice)
 
 // subscribing to a single user
 // author is the user's public key
-pool.sub({cb: onEvent, filter: {author: '<hex>'}})
+pool.sub({filter: {author: '<hex>'}})
 
 //  or bulk follow
-pool.sub({cb:(event, relay) => {...}, filter: {authors: ['<hex1>', '<hex2>', ..., '<hexn>']}})
+pool.sub({filter: {authors: ['<hex1>', '<hex2>', ..., '<hexn>']}})
 
 // reuse a subscription channel
-const mySubscription = pool.sub({cb: ..., filter: ....})
+const mySubscription = pool.sub({filter: ...., skipVerification: false, beforeSend: ....})
 mySubscription.sub({filter: ....})
-mySubscription.sub({cb: ...})
+mySubscription.sub({skipVerification: true})
+
+// listen for messages for subscription
+mySubscription.on('event', onEvent)
+mySubscription.on('eose', onEose)
+
+// close subscription
 mySubscription.unsub()
 
 // get specific event
-const specificChannel = pool.sub({
-  cb: (event, relay) => {
+const specificChannel = pool.sub({ filter: {id: '<hex>'}})
+  .on('event', ({event, relay}) => {
     console.log('got specific event from relay', event, relay)
     specificChannel.unsub()
-  },
-  filter: {id: '<hex>'}
-})
+  })
 
 // or get a specific event plus all the events that reference it in the 'e' tag
-pool.sub({ cb: (event, relay) => { ... }, filter: [{id: '<hex>'}, {'#e': '<hex>'}] })
+pool.sub({ filter: [{id: '<hex>'}, {'#e': '<hex>'}] })
 
 // get all events
-pool.sub({cb: (event, relay) => {...}, filter: {}})
+pool.sub({ filter: {} })
 
 // get recent events
-pool.sub({cb: (event, relay) => {...}, filter: {since: timestamp}})
+pool.sub({ filter: {since: timestamp} })
 
 // publishing events(inside an async function):
 const ev = await pool.publish(eventObject, (status, url) => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import {generatePrivateKey, getPublicKey} from './keys.js'
-import {relayConnect} from './relay.js'
-import {relayPool} from './pool.js'
+import { generatePrivateKey, getPublicKey } from './keys.js'
+import { relayInit } from './relay.js'
+import { relayPool } from './pool.js'
 import {
   getBlankEvent,
   signEvent,
@@ -9,11 +9,11 @@ import {
   serializeEvent,
   getEventHash
 } from './event.js'
-import {matchFilter, matchFilters} from './filter.js'
+import { matchFilter, matchFilters } from './filter.js'
 
 export {
   generatePrivateKey,
-  relayConnect,
+  relayInit,
   relayPool,
   signEvent,
   validateEvent,
@@ -25,3 +25,4 @@ export {
   matchFilter,
   matchFilters
 }
+

--- a/pool.js
+++ b/pool.js
@@ -1,5 +1,5 @@
-import {getEventHash, verifySignature, signEvent} from './event.js'
-import {relayConnect, normalizeRelayURL} from './relay.js'
+import { getEventHash, verifySignature, signEvent } from './event.js'
+import { relayInit, normalizeRelayURL } from './relay.js'
 
 export function relayPool() {
   var globalPrivateKey
@@ -14,74 +14,65 @@ export function relayPool() {
     // been published -- or at least attempted to be published -- to all relays
     wait: false
   }
-  
-  //map with all the relays where the url is the id
-  //Map<string,{relay:Relay,policy:RelayPolicy>
+
+  // map with all the relays where the url is the id
+  // Map<string,{relay:Relay,policy:RelayPolicy>
   const relays = {}
-  const noticeCallbacks = []
-
-  function propagateNotice(notice, relayURL) {
-    for (let i = 0; i < noticeCallbacks.length; i++) {
-      let {relay} = relays[relayURL]
-      noticeCallbacks[i](notice, relay)
-    }
-  }
-
   const activeSubscriptions = {}
+  const poolListeners = { notice: [], connection: [], disconnection: [], error: [] }
 
-  //sub creates a Subscription object {sub:Function, unsub:Function, addRelay:Function,removeRelay :Function }
-  const sub = ({cb, filter, beforeSend}, id, cbEose) => {
-    
-    //check if it has an id, if not assign one
+  // sub creates a Subscription object {sub:Function, unsub:Function, addRelay:Function,removeRelay :Function }
+  const sub = ({ filter, beforeSend, skipVerification }, id) => {
+
+    // check if it has an id, if not assign one
     if (!id) id = Math.random().toString().slice(2)
+    const subListeners = {}
     const subControllers = Object.fromEntries(
-      //Convert the map<string,Relay> to a Relay[]
+      // Convert the map<string,Relay> to a Relay[]
       Object.values(relays)
-         //takes only relays that can be read
-        .filter(({policy}) => policy.read)
-         //iterate all the rellies and create the array [url:string,sub:SubscriptionCallback] 
-        .map(({relay}) => [
+        // takes only relays that can be read
+        .filter(({ policy }) => policy.read)
+        // iterate all the relays and create the array [url:string,sub:SubscriptionCallback, listeners] 
+        .map(({ relay }) => [
           relay.url,
-          relay.sub({cb: event => cb(event, relay.url), filter, beforeSend}, id,
-          () => cbEose(relay.url))
+          relay.sub({ filter, beforeSend, skipVerification }, id),
         ])
     )
 
-    const activeCallback = cb //assign callback for the suscription
-    const activeFilters = filter //assigng filter for the suscrition
-    const activeBeforeSend = beforeSend //assign before send fucntion
+    const activeFilters = filter // assigng filter for the suscrition
+    const activeBeforeSend = beforeSend // assign before send fucntion
+    const activeSkipVerification = skipVerification // assign skipVerification
 
-    //Unsub deletes itself 
+    // Unsub deletes itself 
     const unsub = () => {
-      //iterate the map of subControllers and call the unsub function of it relays 
+      // iterate the map of subControllers and call the unsub function of it relays 
       Object.values(subControllers).forEach(sub => sub.unsub())
-      delete activeSubscriptions[id] 
+      delete activeSubscriptions[id]
     }
-    
-  
+
+
     const sub = ({
-      cb = activeCallback,
       filter = activeFilters,
-      beforeSend = activeBeforeSend
+      beforeSend = activeBeforeSend,
+      skipVerification = activeSkipVerification
     }) => {
-      //Iterates the subControllers and add them the atributes of our Subscription (callback, filter,etc.)
-      Object.entries(subControllers).map(([relayURL, sub]) => [
-        relayURL,
-        sub.sub({cb: event => cb(event, relayURL), filter, beforeSend}, id,
-          () => cbEose(relayURL))
-      ])
-      //returns the current suscripcion
+      // Iterates the subControllers and add them the atributes of our Subscription (callback, filter,etc.)
+      Object.entries(subControllers).forEach(([relayURL, sub]) => {
+        sub.sub({ filter, beforeSend, skipVerification }, id)
+      })
+
+      // returns the current suscripcion
       return activeSubscriptions[id]
     }
-    //addRelay adds a relay to the subControllers map so the current subscription can use it
+    // addRelay adds a relay to the subControllers map so the current subscription can use it
     const addRelay = relay => {
-      subControllers[relay.url] = relay.sub(
-        {cb: event => cb(event, relay.url), filter, beforeSend},
-        id, () => cbEose(relay.url)
-      )
+      for (let type of Object.keys(subListeners)) {
+        if (subListeners[type].length) subListeners[type].forEach(cb => relay.on(type, cb, id))
+      }
+      subControllers[relay.url] = relay.sub({ filter, beforeSend, skipVerification }, id) // TODO filter/before send should reference updated filter/beforesend
       return activeSubscriptions[id]
     }
-    //removeRelay deletes a relay from the subControllers map, it also handles the unsubscription from the relay
+    // removeRelay deletes a relay from the subControllers map, it also handles the unsubscription from the relay
     const removeRelay = relayURL => {
       if (relayURL in subControllers) {
         subControllers[relayURL].unsub()
@@ -89,13 +80,29 @@ export function relayPool() {
       }
       return activeSubscriptions[id]
     }
+    // on creates listener for sub ('EVENT', 'EOSE', etc)
+    const on = (type, cb) => {
+      subListeners[type].push(cb)
+      Object.values(relays).forEach(({ relay }) => relay.on(type, cb, id))
+      return activeSubscriptions[id]
+    }
+    // off destroys listener for sub ('EVENT', 'EOSE', etc)
+    const off = (type, cb) => {
+      if (!subListeners[type].length) return
+      let index = subListeners[type].indexOf(cb)
+      if (index !== -1) subListeners[type].splice(index, 1)
+      Object.values(relays).forEach(({ relay }) => relay.off(type, cb, id))
+      return activeSubscriptions[id]
+    }
 
-    //add the object created to activeSubscriptions map
+    // add the object created to activeSubscriptions map
     activeSubscriptions[id] = {
       sub,
       unsub,
       addRelay,
-      removeRelay
+      removeRelay,
+      on,
+      off
     }
 
     return activeSubscriptions[id]
@@ -113,43 +120,47 @@ export function relayPool() {
     setPolicy(key, value) {
       poolPolicy[key] = value
     },
-    //addRelay adds a relay to the pool and to all its subscriptions
-    addRelay(url, policy = {read: true, write: true}) {
+    // addRelay adds a relay to the pool and to all its subscriptions
+    addRelay(url, policy = { read: true, write: true }) {
       let relayURL = normalizeRelayURL(url)
       if (relayURL in relays) return
 
-      let relay = relayConnect(url, notice => {
-        propagateNotice(notice, relayURL)
-      })
-      relays[relayURL] = {relay, policy}
+      let relay = relayInit(url)
+
+      for (let type of Object.keys(poolListeners)) {
+        let cbs = poolListeners[type] || []
+        if (cbs.length) poolListeners[type].forEach(cb => relay.on(type, cb))
+      }
+      relay.connect()
+      relays[relayURL] = { relay: relay, policy }
 
       if (policy.read) {
-        Object.values(activeSubscriptions).forEach(subscription =>
+        Object.values(activeSubscriptions).forEach(subscription => {
           subscription.addRelay(relay)
-        )
+        })
       }
 
       return relay
     },
-    //remove relay deletes the relay from the pool and from all its subscriptions
+    // remove relay deletes the relay from the pool and from all its subscriptions
     removeRelay(url) {
       let relayURL = normalizeRelayURL(url)
       let data = relays[relayURL]
       if (!data) return
 
-      let {relay} = data
+      let { relay } = data
       Object.values(activeSubscriptions).forEach(subscription =>
         subscription.removeRelay(relay)
       )
       relay.close()
       delete relays[relayURL]
     },
-    //getRelayList return an array with all the relays stored
+    // getRelayList return an array with all the relays stored
     getRelayList() {
       return Object.values(relays)
     },
 
-    relayChangePolicy(url, policy = {read: true, write: true}) {
+    relayChangePolicy(url, policy = { read: true, write: true }) {
       let relayURL = normalizeRelayURL(url)
       let data = relays[relayURL]
       if (!data) return
@@ -158,19 +169,22 @@ export function relayPool() {
 
       return relays[relayURL]
     },
-    onNotice(cb) {
-      noticeCallbacks.push(cb)
+    on(type, cb) {
+      poolListeners[type] = poolListeners[type] || []
+      poolListeners[type].push(cb)
+      Object.values(relays).forEach(({ relay }) => relay.on(type, cb))
     },
-    offNotice(cb) {
-      let index = noticeCallbacks.indexOf(cb)
-      if (index !== -1) noticeCallbacks.splice(index, 1)
+    off(type, cb) {
+      let index = poolListeners[type].indexOf(cb)
+      if (index !== -1) poolListeners[type].splice(index, 1)
+      Object.values(relays).forEach(({ relay }) => relay.off(type, cb))
     },
-    
-    //publish send a event to the relays 
+
+    // publish send a event to the relays 
     async publish(event, statusCallback) {
       event.id = getEventHash(event)
-      
-      //if the event is not signed then sign it 
+
+      // if the event is not signed then sign it 
       if (!event.sig) {
         event.tags = event.tags || []
 
@@ -195,9 +209,9 @@ export function relayPool() {
         }
       }
 
-      //get the writable relays
+      // get the writable relays
       let writeable = Object.values(relays)
-        .filter(({policy}) => policy.write)
+        .filter(({ policy }) => policy.write)
         .sort(() => Math.random() - 0.5) // random
 
       let maxTargets = poolPolicy.randomChoice
@@ -206,10 +220,10 @@ export function relayPool() {
 
       let successes = 0
 
-      //if the pool policy set to want until event send
+      // if the pool policy set to want until event send
       if (poolPolicy.wait) {
         for (let i = 0; i < writeable.length; i++) {
-          let {relay} = writeable[i]
+          let { relay } = writeable[i]
 
           try {
             await new Promise(async (resolve, reject) => {
@@ -231,9 +245,9 @@ export function relayPool() {
             /***/
           }
         }
-        //if the pool policy dont  want to wait  until event send
+        // if the pool policy dont  want to wait  until event send
       } else {
-        writeable.forEach(async ({relay}) => {
+        writeable.forEach(async ({ relay }) => {
           let callback = statusCallback
             ? status => statusCallback(status, relay.url)
             : null


### PR DESCRIPTION
hey fiatjaf and all,

here is my initial refactor of the call back api as proposed by fiatjaf. it replaces all the existing call back arguments with listeners that can be added to the pool, subscription, or relay (if using relay module without the pool module). only 'event' and 'eose' can listen at the sub level, but these can also listen at the pool or relay (again, only if using relay module without the pool module) level as well. current list of listener types:

- event
- eose
- connection
- disconnection
- error
- notice

format of the calls:
pool.on('connection', cb)
pool.on('event', cb)
sub.on('eose', cb)
relay.on('notice', cb)

this hasn't been thoroughly tested yet (though seems to work from cursory testing) but wanted to get eyes on this sooner rather then later in case I need to be redirected.

other major changes: 

- I changed connectRelay to relayInit and then added a new method 'connect' to connect to the relay. I did this because I didn't know how else to allow creation of listeners on the relay prior the relay connecting. please let me know if there is a better method of solving this problem (I see a similar problem with creating the sub, where you don't have a chance to set listeners on the sub prior opening the sub).
- all listener call back functions take only 1 argument, an object that has the following keys:
   * relay: relay url
   * type: type of listener
   * id: sub id for sub specific listeners ('EVENT' or 'EOSE')
   * event: event object, only for 'event' listener
   * notice: notice message, only for 'notice' listener