### PR TITLE
relay.status() returns 0 when ws not created

### DIFF
--- a/relay.ts
+++ b/relay.ts
@@ -305,7 +305,7 @@ export function relayInit(url: string): Relay {
       })
     },
     get status() {
-      return ws?.readyState ?? 0
+      return ws?.readyState ?? 3
     }
   }
 }

--- a/relay.ts
+++ b/relay.ts
@@ -305,7 +305,7 @@ export function relayInit(url: string): Relay {
       })
     },
     get status() {
-      return ws.readyState
+      return ws?.readyState ?? 0
     }
   }
 }


### PR DESCRIPTION
Avoid error
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'readyState')
    at get status [as status] (nostr.esm.js?9e27:346:1)
    at eval (Nostr.ts?6cf9:77:1)
```