### PR TITLE
Fix connect/close return types and race condition

### DIFF
--- a/relay.ts
+++ b/relay.ts
@@ -6,8 +6,8 @@ import {Filter, matchFilters} from './filter'
 export type Relay = {
   url: string
   status: number
-  connect: () => void
-  close: () => void
+  connect: () => Promise<void>
+  close: () => Promise<void>
   sub: (filters: Filter[], opts: SubscriptionOptions) => Sub
   publish: (event: Event) => Pub
   on: (type: 'connect' | 'disconnect' | 'notice', cb: any) => void
@@ -257,10 +257,11 @@ export function relayInit(url: string): Relay {
     },
     connect,
     close(): Promise<void> {
-      ws.close()
-      return new Promise(resolve => {
+      const result = new Promise<void>(resolve => {
         resolveClose = resolve
       })
+      ws.close()
+      return result
     },
     get status() {
       return ws?.readyState ?? 3


### PR DESCRIPTION
Connect and close should return promises, the promise in close should be created before closing the socket, otherwise `resolveClose` is `undefined` in `ws.onclose`.