### PR TITLE
Issue #62: documentation fix — node.js v19 is now required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tools for developing [Nostr](https://github.com/fiatjaf/nostr) clients.
 
-Very lean on dependencies.
+Very lean on dependencies. Node.js version 19+ is supported.
 
 ## Usage
 

--- a/nip04.test.js
+++ b/nip04.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-globalThis.crypto = require('crypto')
+// globalThis.crypto = require('crypto')
 const {nip04, getPublicKey, generatePrivateKey} = require('./lib/nostr.cjs')
 
 test('encrypt and decrypt message', async () => {


### PR DESCRIPTION
If merged, this PR modifies the readme to say that Node v19+ is required.