### PR TITLE
Fix resolveClose

### DIFF
--- a/relay.ts
+++ b/relay.ts
@@ -73,7 +73,7 @@ export function relayInit(url: string): Relay {
       }
       ws.onclose = async () => {
         listeners.disconnect.forEach(cb => cb())
-        resolveClose()
+        resolveClose && resolveClose()
       }
 
       ws.onmessage = async e => {
@@ -257,11 +257,10 @@ export function relayInit(url: string): Relay {
     },
     connect,
     close(): Promise<void> {
-      const result = new Promise<void>(resolve => {
+      ws.close()
+      return new Promise<void>(resolve => {
         resolveClose = resolve
       })
-      ws.close()
-      return result
     },
     get status() {
       return ws?.readyState ?? 3


### PR DESCRIPTION
I apologize, my fix was misleading. The problem is that `ws.onclose` is also called when the socket is closed by the system (i.e. not us), in that case `resolveClose` isn't set (it's only set if we call the relay object's method `close`) so to prevent this error it should be checked. There's no race condition actually.