### PR TITLE
Make `opts` arg optional for `sub` method

### DIFF
--- a/relay.ts
+++ b/relay.ts
@@ -8,7 +8,7 @@ export type Relay = {
   status: number
   connect: () => Promise<void>
   close: () => Promise<void>
-  sub: (filters: Filter[], opts: SubscriptionOptions) => Sub
+  sub: (filters: Filter[], opts?: SubscriptionOptions) => Sub
   publish: (event: Event) => Pub
   on: (type: 'connect' | 'disconnect' | 'notice', cb: any) => void
   off: (type: 'connect' | 'disconnect' | 'notice', cb: any) => void


### PR DESCRIPTION
In the README and the code, it looks like the second argument for the relay's `sub` method is optional:

```typescript
let sub = relay.sub([
  {
    ids: ['d7dd5eb3ab747e16f8d0212d53032ea2a7cadef53837e5a6c66d42849fcb9027']
  }
])
```

In the type definitions it's required however, which leads to an error in editors:

<img width="646" alt="CleanShot 2022-12-25 at 13 30 01@2x" src="https://user-images.githubusercontent.com/2598660/209467974-d2aefaf9-665d-449d-bc49-e305df0fe972.png">

Let's mark it as optional in the type definitions too! 👍