### PR TITLE
Add missing "error" event to `on` and `off` type definitions

### DIFF
--- a/relay.ts
+++ b/relay.ts
@@ -3,6 +3,8 @@
 import {Event, verifySignature, validateEvent} from './event'
 import {Filter, matchFilters} from './filter'
 
+type RelayEvent = 'connect' | 'disconnect' | 'error' | 'notice'
+
 export type Relay = {
   url: string
   status: number
@@ -10,8 +12,8 @@ export type Relay = {
   close: () => Promise<void>
   sub: (filters: Filter[], opts: SubscriptionOptions) => Sub
   publish: (event: Event) => Pub
-  on: (type: 'connect' | 'disconnect' | 'notice', cb: any) => void
-  off: (type: 'connect' | 'disconnect' | 'notice', cb: any) => void
+  on: (type: RelayEvent, cb: any) => void
+  off: (type: RelayEvent, cb: any) => void
 }
 export type Pub = {
   on: (type: 'ok' | 'seen' | 'failed', cb: any) => void
@@ -185,7 +187,7 @@ export function relayInit(url: string): Relay {
     url,
     sub,
     on: (
-      type: 'connect' | 'disconnect' | 'error' | 'notice',
+      type: RelayEvent,
       cb: any
     ): void => {
       listeners[type].push(cb)
@@ -194,7 +196,7 @@ export function relayInit(url: string): Relay {
       }
     },
     off: (
-      type: 'connect' | 'disconnect' | 'error' | 'notice',
+      type: RelayEvent,
       cb: any
     ): void => {
       let index = listeners[type].indexOf(cb)


### PR DESCRIPTION
If you try to use the `.on("error", ...` flow defined in the README, you currently get this error in editors:

<img width="1270" alt="CleanShot 2022-12-25 at 13 43 09@2x" src="https://user-images.githubusercontent.com/2598660/209468371-6182436b-ac8d-4107-9899-2527afea61c6.png">

In order to make sure that the type definitions are consistent throughout the file, I think it makes sense to extract this into its own type.